### PR TITLE
Panel appears only on Shopify store

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -11,13 +11,20 @@ const selectors = {
   initialMessage: '[data-initial-message]',
 };
 
-const toolbar = new Toolbar();
 let liquidFlamegraph: LiquidFlamegraph;
 
-chrome.devtools.panels.create('Shopify', '', './devtools.html');
+chrome.devtools.inspectedWindow.eval(
+  `typeof window.Shopify === 'object'`,
+  function(isShopifyStore: boolean) {
+    if (isShopifyStore) {
+      chrome.devtools.panels.create('Shopify', '', './devtools.html');
+      const toolbar = new Toolbar();
 
-toolbar.refreshButton.addEventListener('click', refreshPanel);
-toolbar.zoomOutButton.addEventListener('click', zoomOutFlamegraph);
+      toolbar.refreshButton.addEventListener('click', refreshPanel);
+      toolbar.zoomOutButton.addEventListener('click', zoomOutFlamegraph);
+    }
+  },
+);
 
 async function refreshPanel() {
   document.querySelector(selectors.initialMessage)!.innerHTML = '';


### PR DESCRIPTION
### Why is this change needed?
The devtools panel should only appear on a Shopify store otherwise interaction with the panel has undefined behavior.

This change makes sure that the panel only shows up on a shopify store using the `typeof window.Shopify` property.

Currently this change is for the panel. How to disable extension icon appropriately is still under investigation.