### PR TITLE
Format inspected node details to look better

### DIFF
--- a/src/components/liquid-flamegraph.ts
+++ b/src/components/liquid-flamegraph.ts
@@ -2,6 +2,7 @@ import * as d3 from 'd3';
 import * as flamegraph from 'd3-flame-graph';
 import 'd3-flame-graph/dist/d3-flamegraph.css';
 import {debounce} from 'lodash';
+import {formatNodeTime} from '../utils';
 
 const selectors = {
   partial: '[data-partial]',
@@ -63,11 +64,11 @@ export default class LiquidFlamegraph {
 
     document.querySelector(
       selectors.nodeTime,
-    )!.innerHTML = `Total Time: ${node.value}`;
+    )!.innerHTML = `Total Time: <b>${formatNodeTime(node.value)}ms</b>`;
 
     document.querySelector(
       selectors.code,
-    )!.innerHTML = `Code snippet: ${node.data.code}`;
+    )!.innerHTML = `Code snippet: <i><span class="code-snippet">${node.data.code}</span></i>`;
 
     document.querySelector(
       selectors.line,

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,6 +1,6 @@
 import Toolbar from './components/toolbar';
 import LiquidFlamegraph from './components/liquid-flamegraph';
-import {domHelpers, getProfileData} from './utils';
+import {toggleDisplay, getProfileData, setTotalTime} from './utils';
 
 import './styles/main.css';
 
@@ -21,9 +21,9 @@ toolbar.zoomOutButton.addEventListener('click', zoomOutFlamegraph);
 
 async function refreshPanel() {
   document.querySelector(selectors.initialMessage)!.innerHTML = '';
-  domHelpers.toggleDisplay(selectors.loadingAnimation);
+  toggleDisplay(selectors.loadingAnimation);
   const profile = await getProfileData();
-  domHelpers.toggleDisplay(selectors.loadingAnimation);
+  toggleDisplay(selectors.loadingAnimation);
 
   liquidFlamegraph = new LiquidFlamegraph(
     document.querySelector(selectors.flamegraphContainer),
@@ -31,7 +31,7 @@ async function refreshPanel() {
   );
 
   setTimeout(function() {
-    domHelpers.setTotalTime(profile.value);
+    setTotalTime(profile.value);
   }, 300);
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -53,3 +53,9 @@ body {
   margin: 20px;
   font-size: 13px;
 }
+
+.code-snippet {
+  background-color: rgb(243, 243, 243);
+  border: 1px solid rgb(208, 208, 208);
+  padding: 4px;
+}

--- a/src/utils/domHelpers.ts
+++ b/src/utils/domHelpers.ts
@@ -10,3 +10,12 @@ export function setTotalTime(totalTime) {
     Number(totalTime) * 1000,
   )}ms</b>`;
 }
+
+export function formatNodeTime(nodeTime) {
+  const nodeTimeMs = Math.trunc(nodeTime * 1000);
+  if (nodeTimeMs > 0) {
+    return nodeTimeMs;
+  } else {
+    return '< 1';
+  }
+}

--- a/src/utils/getProfileData.ts
+++ b/src/utils/getProfileData.ts
@@ -41,6 +41,8 @@ function cleanProfileData(profileData: {name: any; value: any; children: any}) {
   const cleanData = {
     name: profileData.name,
     value: profileData.value,
+    code: '-',
+    line: '-',
     children: formatLiquidProfileData(profileData.children),
   };
   return cleanData;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
 import getProfileData from './getProfileData';
-import * as domHelpers from './domHelpers';
+import {toggleDisplay, setTotalTime, formatNodeTime} from './domHelpers';
 
-export {getProfileData, domHelpers};
+export {getProfileData, toggleDisplay, setTotalTime, formatNodeTime};


### PR DESCRIPTION
### Before
<img width="685" alt="Screen Shot 2019-10-23 at 11 13 13 AM" src="https://user-images.githubusercontent.com/55554767/67407862-1fd53500-f586-11e9-9193-ee70c0ee3ccb.png">

### After
<img width="748" alt="Screen Shot 2019-10-23 at 11 10 10 AM" src="https://user-images.githubusercontent.com/55554767/67407710-e997b580-f585-11e9-9717-64164cb334dd.png">

### Other changes
Got rid of the `domHelpers` namespace a change requested in the previous PR that I missed to change. Now the helpers are imported individually on an as needed basis.