### PR TITLE
Enable code snippet line to be clickable leading to file in admin

### DIFF
--- a/src/components/liquid-flamegraph.ts
+++ b/src/components/liquid-flamegraph.ts
@@ -2,7 +2,7 @@ import * as d3 from 'd3';
 import * as flamegraph from 'd3-flame-graph';
 import 'd3-flame-graph/dist/d3-flamegraph.css';
 import {debounce} from 'lodash';
-import {formatNodeTime} from '../utils';
+import {formatNodeTime, getThemeId, getURL} from '../utils';
 
 const selectors = {
   partial: '[data-partial]',
@@ -57,7 +57,7 @@ export default class LiquidFlamegraph {
     return window.innerWidth - 40;
   }
 
-  displayNodeDetails(node): void {
+  async displayNodeDetails(node) {
     document.querySelector(
       selectors.partial,
     )!.innerHTML = `File: ${node.data.name}`;
@@ -66,13 +66,27 @@ export default class LiquidFlamegraph {
       selectors.nodeTime,
     )!.innerHTML = `Total Time: <b>${formatNodeTime(node.value)}ms</b>`;
 
+    const clickableLink = await this.generateClickableLink(
+      node.data.name,
+      node.data.line,
+    );
+
     document.querySelector(
       selectors.code,
-    )!.innerHTML = `Code snippet: <i><span class="code-snippet">${node.data.code}</span></i>`;
+    )!.innerHTML = `Code snippet: <a href="${clickableLink}" target="_blank"><i><span class="code-snippet">${node.data.code}</span></i></a>`;
 
     document.querySelector(
       selectors.line,
     )!.innerHTML = `Line: ${node.data.line}`;
+  }
+
+  async generateClickableLink(fileName, lineNumber): Promise<any> {
+    const url = new URL(await getURL());
+    const hostname = url.hostname;
+    const themeId = await getThemeId();
+    const fileDetails = fileName.split(':');
+    const link = `https://${hostname}/admin/themes/${themeId}?key=${fileDetails[0]}s/${fileDetails[1]}.liquid&line=${lineNumber}`;
+    return link;
   }
 
   destroy() {

--- a/src/utils/getProfileData.ts
+++ b/src/utils/getProfileData.ts
@@ -1,7 +1,7 @@
-export default async function getProfileData() {
+export async function getProfileData() {
   let profileData;
   try {
-    const url = new URL(await getProfileURL());
+    const url = new URL(await getURL());
     url.searchParams.set('profile_liquid', 'true');
     const response = await fetch(url.href);
     const html = await response.text();
@@ -28,7 +28,7 @@ function formatLiquidProfileData(entries) {
   });
 }
 
-function getProfileURL(): Promise<string> {
+export function getURL(): Promise<string> {
   return new Promise(resolve => {
     chrome.devtools.inspectedWindow.eval(
       'window.location.href',

--- a/src/utils/getThemeId.ts
+++ b/src/utils/getThemeId.ts
@@ -1,0 +1,7 @@
+export default function getThemeId() {
+  return new Promise(resolve => {
+    chrome.devtools.inspectedWindow.eval('Shopify.theme.id', (result: string) =>
+      resolve(result),
+    );
+  });
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,12 @@
-import getProfileData from './getProfileData';
+import {getProfileData, getURL} from './getProfileData';
 import {toggleDisplay, setTotalTime, formatNodeTime} from './domHelpers';
+import getThemeId from './getThemeId';
 
-export {getProfileData, toggleDisplay, setTotalTime, formatNodeTime};
+export {
+  getProfileData,
+  toggleDisplay,
+  setTotalTime,
+  formatNodeTime,
+  getThemeId,
+  getURL,
+};


### PR DESCRIPTION
### What's the change?
When a node is clicked the detailed info for that node is displayed in the devtools panel. This PR makes the code snippet line clickable which jumps straight into the code editor mode of the file to the line number indicated in the details. User has to be signed in as admin to use this link.

### Change that needs attention
From my small period of investigation the link string I'm generating looks good but could stores in special cases have different links?