### PR TITLE
Add snippet label and format time label on flamegraph

### DIFF
--- a/src/components/liquid-flamegraph.ts
+++ b/src/components/liquid-flamegraph.ts
@@ -44,7 +44,7 @@ export default class LiquidFlamegraph {
       .cellHeight(20)
       .width(flameGraphWidth)
       .label(function(node: FlamegraphNode) {
-        return `${node.data.name} took ${node.value}s`;
+        return `${node.data.name} took ${formatNodeTime(node.value)}ms`;
       })
       .onClick((node: FlamegraphNode) => {
         this.displayNodeDetails(node);

--- a/src/utils/getProfileData.ts
+++ b/src/utils/getProfileData.ts
@@ -20,6 +20,9 @@ function formatLiquidProfileData(
   entries: ProfileNode[],
 ): FormattedProfileNode[] {
   return entries.map(function(entry: ProfileNode) {
+    if (!entry.partial.includes(':')) {
+      entry.partial = `snippet:${entry.partial}`;
+    }
     return {
       name: `${entry.partial}`,
       value: entry.total_time,


### PR DESCRIPTION
### What issue does this pull request address?

Snippet files were not associated with a snippet tag which breaks the clickable link.

### What is the solution

There is already support for `template`, `section` and `layout` through core. If there is no such label mark it as a `snippet`.

This PR also formats node times on flamegraph label.

