### PR TITLE
Remove un-need permissions

### DIFF
--- a/src/components/liquid-flamegraph.ts
+++ b/src/components/liquid-flamegraph.ts
@@ -2,7 +2,7 @@ import * as d3 from 'd3';
 import * as flamegraph from 'd3-flame-graph';
 import 'd3-flame-graph/dist/d3-flamegraph.css';
 import {debounce} from 'lodash';
-import {formatNodeTime, getThemeId, getCurrentTabURL} from '../utils';
+import {formatNodeTime, getThemeId} from '../utils';
 
 const selectors = {
   partial: '[data-partial]',
@@ -12,15 +12,17 @@ const selectors = {
 };
 
 export default class LiquidFlamegraph {
+  url: URL;
   element: HTMLDivElement;
   profile: object;
   flamegraph: any;
   debouncedResize: any;
 
-  constructor(element: HTMLDivElement | null, profile: object) {
+  constructor(url: URL, element: HTMLDivElement | null, profile: object) {
     if (!element) {
       throw new TypeError('Element does not exist on page');
     }
+    this.url = url;
     this.element = element;
     this.profile = profile;
     this.flamegraph = this.create(this.curWindowWidth());
@@ -87,8 +89,7 @@ export default class LiquidFlamegraph {
     fileName: string,
     lineNumber: number,
   ): Promise<any> {
-    const url = await getCurrentTabURL();
-    const hostname = url.hostname;
+    const hostname = this.url.hostname;
     const themeId = await getThemeId();
     const fileDetails = fileName.split(':');
     const link = `https://${hostname}/admin/themes/${themeId}?key=${fileDetails[0]}s/${fileDetails[1]}.liquid&line=${lineNumber}`;

--- a/src/detectShopify.ts
+++ b/src/detectShopify.ts
@@ -16,6 +16,7 @@ window.addEventListener('message', function(evt) {
   if (typeof evt.data.hasDetectedShopify !== 'undefined') {
     chrome.runtime.sendMessage({
       hasDetectedShopify: evt.data.hasDetectedShopify,
+      url: evt.data.url,
     });
   }
 });
@@ -26,6 +27,7 @@ window.addEventListener('message', function(evt) {
 const detectShopify = `
   window.postMessage({
     hasDetectedShopify: typeof window.Shopify !== 'undefined',
+    url: document.location.href,
   }, '*');
 `;
 

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -14,6 +14,14 @@ const selectors = {
 };
 
 let liquidFlamegraph: LiquidFlamegraph;
+let url: URL;
+
+// Get the url from the inspectedWindow and save it
+chrome.devtools.inspectedWindow.eval('document.location.href', function(
+  currentUrl: string,
+) {
+  url = new URL(currentUrl);
+});
 
 chrome.devtools.inspectedWindow.eval(
   `typeof window.Shopify === 'object'`,
@@ -44,14 +52,15 @@ async function refreshPanel() {
   try {
     try {
       // Try first to make an unauthorized request if the beta flag is enabled
-      profile = await getProfileData(false);
+      profile = await getProfileData(url, false);
     } catch (error) {
       // If no profiling data exists in first request, try an authorized request
       console.error(error);
-      profile = await getProfileData();
+      profile = await getProfileData(url);
     }
 
     liquidFlamegraph = new LiquidFlamegraph(
+      url,
       document.querySelector(selectors.flamegraphContainer),
       profile,
     );

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,11 @@
   "version": "0.1.0",
   "description": "Profile and debug Liquid template on your Shopify store",
   "devtools_page": "devtools.html",
-  "permissions": ["declarativeContent", "storage", "<all_urls>", "activeTab", "identity"],
+  "permissions": [
+    "activeTab",
+    "identity",
+    "storage"
+  ],
   "background": {
     "scripts": ["background.js"],
     "persistent": false

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,6 @@
   "description": "Profile and debug Liquid template on your Shopify store",
   "devtools_page": "devtools.html",
   "permissions": [
-    "activeTab",
     "identity",
     "storage"
   ],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,8 @@
   "devtools_page": "devtools.html",
   "permissions": [
     "identity",
-    "storage"
+    "storage",
+    "https://*/*"
   ],
   "background": {
     "scripts": ["background.js"],

--- a/src/utils/getProfileData.ts
+++ b/src/utils/getProfileData.ts
@@ -1,13 +1,12 @@
 import nullthrows from 'nullthrows';
 import {SubjectAccessToken} from 'types';
-import {getCurrentTabURL} from '.';
 
 export async function getProfileData(
+  url: URL,
   withAuthorization = true,
 ): Promise<FormattedProfileData> {
   const parser = new DOMParser();
 
-  const url = await getCurrentTabURL();
   const fetchOptions = {} as any;
 
   if (withAuthorization) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -5,15 +5,15 @@ export function getCurrentTabURL(): Promise<URL> {
     chrome.tabs.query({active: true, lastFocusedWindow: true}, function (tabs) {
       if (tabs.length === 0) {
         reject(new Error('Unable to retrieve URL'));
+      } else {
+        const url = tabs[0].url;
+
+        if (url) {
+          resolve(new URL(url));
+        }
+
+        reject(new Error('Unable to retrieve URL'));
       }
-
-      const url = tabs[0].url;
-
-      if (url) {
-        resolve(new URL(url));
-      }
-
-      reject(new Error('Unable to retrieve URL'));
     });
   });
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,7 +2,11 @@ const IS_CHROME = navigator.userAgent.indexOf('Firefox') < 0;
 
 export function getCurrentTabURL(): Promise<URL> {
   return new Promise((resolve, reject) => {
-    chrome.tabs.query({active: true, lastFocusedWindow: true}, function(tabs) {
+    chrome.tabs.query({active: true, lastFocusedWindow: true}, function (tabs) {
+      if (tabs.length === 0) {
+        reject(new Error('Unable to retrieve URL'));
+      }
+
       const url = tabs[0].url;
 
       if (url) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,28 +1,5 @@
 const IS_CHROME = navigator.userAgent.indexOf('Firefox') < 0;
 
-export function getCurrentTabURL(): Promise<URL> {
-  return new Promise((resolve, reject) => {
-    chrome.tabs.query({active: true, lastFocusedWindow: true}, function (tabs) {
-      if (tabs.length === 0) {
-        reject(new Error('No Tabs returned'));
-      } else {
-        const url = tabs[0].url;
-
-        if (url) {
-          resolve(new URL(url));
-        }
-
-        reject(new Error('Unable to retrieve URL'));
-      }
-    });
-  });
-}
-
-export async function isDev(): Promise<boolean> {
-  const {href} = await getCurrentTabURL();
-  return href.includes('shop1.myshopify');
-}
-
 export function getThemeId() {
   return new Promise(resolve => {
     chrome.devtools.inspectedWindow.eval('Shopify.theme.id', (result: string) =>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,7 +4,7 @@ export function getCurrentTabURL(): Promise<URL> {
   return new Promise((resolve, reject) => {
     chrome.tabs.query({active: true, lastFocusedWindow: true}, function (tabs) {
       if (tabs.length === 0) {
-        reject(new Error('Unable to retrieve URL'));
+        reject(new Error('No Tabs returned'));
       } else {
         const url = tabs[0].url;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 export {getProfileData} from './getProfileData';
-export {getCurrentTabURL, isDev, getThemeId, getBrowserTheme} from './helpers';
+export {getThemeId, getBrowserTheme} from './helpers';
 export {setTotalTime, formatNodeTime} from './domHelpers';
 export {Oauth2} from './oauth2';
 export {

--- a/test/devtools.test.ts
+++ b/test/devtools.test.ts
@@ -2,7 +2,6 @@ import {
   setupRequestInterception,
   mockChromeSendMessage,
   getExtensionId,
-  mockChromeTabs,
 } from './test-helpers';
 
 describe('Devtools', () => {
@@ -10,7 +9,6 @@ describe('Devtools', () => {
     const extensionId = await getExtensionId();
     await setupRequestInterception(page);
     await mockChromeSendMessage(page);
-    await mockChromeTabs(page);
     await page.goto(`chrome-extension://${extensionId}/devtools.html`);
   });
 

--- a/test/devtools.test.ts
+++ b/test/devtools.test.ts
@@ -2,6 +2,7 @@ import {
   setupRequestInterception,
   mockChromeSendMessage,
   getExtensionId,
+  mockChromeTabs,
 } from './test-helpers';
 
 describe('Devtools', () => {
@@ -9,6 +10,7 @@ describe('Devtools', () => {
     const extensionId = await getExtensionId();
     await setupRequestInterception(page);
     await mockChromeSendMessage(page);
+    await mockChromeTabs(page);
     await page.goto(`chrome-extension://${extensionId}/devtools.html`);
   });
 

--- a/test/devtools.test.ts
+++ b/test/devtools.test.ts
@@ -2,7 +2,7 @@ import {
   setupRequestInterception,
   mockChromeSendMessage,
   getExtensionId,
-  mockChromeTabs,
+  mockChromeInspectWindow,
 } from './test-helpers';
 
 describe('Devtools', () => {
@@ -10,7 +10,7 @@ describe('Devtools', () => {
     const extensionId = await getExtensionId();
     await setupRequestInterception(page);
     await mockChromeSendMessage(page);
-    await mockChromeTabs(page);
+    await mockChromeInspectWindow(page);
     await page.goto(`chrome-extension://${extensionId}/devtools.html`);
   });
 

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -3,6 +3,19 @@ import {mockProfileData} from './mock-data/mock-profile-data';
 import openIdConfiguration from './mock-data/openid-configuration.json';
 import {mockAccessToken} from './mock-data/mock-access-token';
 
+export function mockChromeTabs(page: any) {
+  return page.evaluateOnNewDocument(`
+    window.chrome = window.chrome || {};
+    window.chrome.devtools = window.chrome.devtools || {};
+    window.chrome.devtools.inspectedWindow = window.chrome.devtools.inspectedWindow || {};
+    window.chrome.devtools.panels = window.chrome.devtools.panels || {};
+
+    window.chrome.devtools.inspectedWindow.eval = function(value, cb) {
+      return cb('https://shop1.myshopify.io/?profile_liquid=true')
+    };
+  `);
+}
+
 export function setDevtoolsEval(page: any) {
   return page.evaluateOnNewDocument(`
       window.chrome = window.chrome || {};

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -3,17 +3,6 @@ import {mockProfileData} from './mock-data/mock-profile-data';
 import openIdConfiguration from './mock-data/openid-configuration.json';
 import {mockAccessToken} from './mock-data/mock-access-token';
 
-export function mockChromeTabs(page: any) {
-  return page.evaluateOnNewDocument(`
-    window.chrome = window.chrome || {};
-    window.chrome.tabs = window.chrome.tabs || {};
-
-    window.chrome.tabs.query = function(options, cb) {
-      cb([{url: 'https://shop1.myshopify.io/?profile_liquid=true'}])
-    }
-  `);
-}
-
 export function setDevtoolsEval(page: any) {
   return page.evaluateOnNewDocument(`
       window.chrome = window.chrome || {};

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -3,7 +3,7 @@ import {mockProfileData} from './mock-data/mock-profile-data';
 import openIdConfiguration from './mock-data/openid-configuration.json';
 import {mockAccessToken} from './mock-data/mock-access-token';
 
-export function mockChromeTabs(page: any) {
+export function mockChromeInspectWindow(page: any) {
   return page.evaluateOnNewDocument(`
     window.chrome = window.chrome || {};
     window.chrome.devtools = window.chrome.devtools || {};


### PR DESCRIPTION
Chrome extension was rejected due to too much user permission that the extension doesn't need.
* Remove permission `declarativeContent`, `<all_urls>`
* Completely remove the need of `activeTab` permission
* Scope to https domains only