### PR TITLE
Ignore domain redirect

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -34,10 +34,10 @@ chrome.devtools.inspectedWindow.eval(
 
 function getInspectedWindowURL(): Promise<URL> {
   return new Promise(resolve => {
-    chrome.devtools.inspectedWindow.eval('document.location.href', function(
+    chrome.devtools.inspectedWindow.eval('Shopify.shop', function(
       currentUrl: string,
     ) {
-      resolve(new URL(currentUrl));
+      resolve(new URL(`https://${currentUrl}`));
     });
   });
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Shopify Theme Inspector for Chrome",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Profile and debug Liquid template on your Shopify store",
   "devtools_page": "devtools.html",
   "permissions": ["storage", "identity", "activeTab"],

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -24,8 +24,8 @@ export function setDevtoolsEval(page: any) {
       window.chrome.devtools.inspectedWindow.eval = function(value, cb){
         if (value === "typeof window.Shopify === 'object'") {
           return cb(true)
-        } else if (value === "document.location.href") {
-          return cb('https://shop1.myshopify.io')
+        }  else if (value === "Shopify.shop") {
+          return cb('shop1.myshopify.io')
         }
       };
       window.chrome.devtools.panels.create = () => {};


### PR DESCRIPTION
Fixes #33 
Fixes #34 

### What issue does this pull request address?
* Custom domain shops are not able to get a liquid profile render even if they are a staff account with full permission

### What is the solution

* Use shop original URI to request for profiling

### What should the reviewer focus on and are there any special considerations?

* Liquid profiling works with custom domains

