### PR TITLE
Set minFrameSize to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Change Log
 
-## v1.0.2 (Jan 27, 2019)
+## v1.0.3 (Feb 1, 2020)
+
+* [#40](https://github.com/Shopify/shopify-theme-inspector/pull/40) Set minFrameSize to 5
+
+## v1.0.2 (Jan 27, 2020)
 
 * [#39](https://github.com/Shopify/shopify-theme-inspector/pull/39) Fix profiling path
 
-## v1.0.1 (Jan 27, 2019)
+## v1.0.1 (Jan 27, 2020)
 
 * [#37](https://github.com/Shopify/shopify-theme-inspector/pull/37) Fix custom domain redirect
 * [#38](https://github.com/Shopify/shopify-theme-inspector/pull/38) Address security concern
 
-## v1.0.0 (Jan. 14, 2019)
+## v1.0.0 (Jan. 14, 2020)
 
 * First release of the extension

--- a/src/components/liquid-flamegraph.ts
+++ b/src/components/liquid-flamegraph.ts
@@ -49,6 +49,7 @@ export default class LiquidFlamegraph {
       .flamegraph()
       .inverted(true)
       .cellHeight(20)
+      .minFrameSize(5)
       .width(flameGraphWidth)
       .label(function(node: FlamegraphNode) {
         return `${node.data.name} took ${formatNodeTime(node.value)}ms`;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Shopify Theme Inspector for Chrome",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Profile and debug Liquid template on your Shopify store",
   "devtools_page": "devtools.html",
   "permissions": ["storage", "identity", "activeTab"],


### PR DESCRIPTION
### What issue does this pull request address?
With large datasets, performance is really struggling and it is almost impossible to navigate through the graph.

Here's the difference in video:

Before: https://cl.ly/7484af426a56
After: https://cl.ly/67cb15025c1a

### What is the solution
Set [minFrameSize](https://github.com/spiermar/d3-flame-graph#minFrameSize) to 5px.
```
Minimum size of a frame, in px, to be displayed in the flame graph. Defaults to 0px if not set. If size is specified, it will set the minimum frame size, otherwise it will return the current minimum frame size.
```

### What should the reviewer focus on and are there any special considerations?
Do we want something else than 5px?
