### PR TITLE
HTML-escape flamegraph tooltip label

### DIFF
--- a/src/components/liquid-flamegraph.ts
+++ b/src/components/liquid-flamegraph.ts
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 import * as flamegraph from 'd3-flame-graph';
 import 'd3-flame-graph/dist/d3-flamegraph.css';
-import {debounce} from 'lodash';
+import {debounce, escape} from 'lodash';
 import {
   formatNodeTime,
   getThemeId,
@@ -52,7 +52,7 @@ export default class LiquidFlamegraph {
       .minFrameSize(1)
       .width(flameGraphWidth)
       .label(function(node: FlamegraphNode) {
-        return `${node.data.name} took ${formatNodeTime(node.value)}ms`;
+        return escape(`${node.data.name} took ${formatNodeTime(node.value)}ms`);
       })
       .onClick((node: FlamegraphNode) => {
         this.displayNodeDetails(node);


### PR DESCRIPTION
### What issue does this pull request address?

Input from the `liquidProfileData` element is passed into d3-flame-graph's `label()` input without HTML escaping. [This is an HTML input](https://github.com/spiermar/d3-flame-graph/blob/0e847e72c9a6bba035aa1a0ff1da5ec9c9ca288f/src/flamegraph.js#L92-L96), so text input must be escaped to prevent rendering errors and cross-site scripting.

<img width="862" alt="Screen Shot 2020-02-05 at 1 22 39 PM" src="https://user-images.githubusercontent.com/11052374/73879405-6b0c0e80-482a-11ea-86cd-b71cd1443ee9.png">

### What is the solution

Use lodash's `escape` function to convert the input from text to HTML. After this change, the tooltip renders correctly:

<img width="1315" alt="Screen Shot 2020-02-05 at 3 21 01 PM" src="https://user-images.githubusercontent.com/11052374/73879831-22a12080-482b-11ea-83a7-fd80360e354b.png">

### What should the reviewer focus on and are there any special considerations?



