### PR TITLE
Don't lose search params on profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.5
 * [#49](https://github.com/Shopify/shopify-theme-inspector/pull/49) Local development url detect
+* [#52](https://github.com/Shopify/shopify-theme-inspector/pull/52) Allow search path profiling
 
 ## v1.0.4 (Feb 11, 2020)
 

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -82,7 +82,7 @@ function clear() {
 function getInspectedWindowURL(): Promise<URL> {
   return new Promise(resolve => {
     chrome.devtools.inspectedWindow.eval(
-      `(/myshopify\\.io/.test(document.location.host) ? document.location.host : Shopify.shop) + document.location.pathname`,
+      `(/myshopify\\.io/.test(document.location.host) ? document.location.host : Shopify.shop) + document.location.pathname + document.location.search`,
       function(currentUrl: string) {
         resolve(new URL(`https://${currentUrl}`));
       },


### PR DESCRIPTION
### What issue does this pull request address?

A theme can have alternate views which is accessible by `<store_url>?view=alternate` when a `index.alternate.liquid` exists in the theme bundle

### What is the solution

Make sure the profiling url includes the search param from the url

