### PR TITLE
Add collaborator scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v1.0.6
+* [#53](https://github.com/Shopify/shopify-theme-inspector/pull/53) Add collaborator scope
+
 ## v1.0.5
 * [#49](https://github.com/Shopify/shopify-theme-inspector/pull/49) Local development url detect
 * [#52](https://github.com/Shopify/shopify-theme-inspector/pull/52) Allow search path profiling

--- a/src/background.ts
+++ b/src/background.ts
@@ -16,9 +16,8 @@ function getOauth2Client(origin: string) {
   const clientAuthParams = [
     [
       'scope',
-      `openid profile ${DEVTOOLS_SCOPE}`,
-      'https://api.shopify.com/auth/partners.collaborator-relationships.readonly',
-    ],
+      `openid profile ${DEVTOOLS_SCOPE} https://api.shopify.com/auth/partners.collaborator-relationships.readonly`,
+    ]
   ];
 
   return new Oauth2(clientId, subjectId, identityDomain, {clientAuthParams});

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,6 +2,8 @@ import {env} from './env';
 import {isDev, Oauth2} from './utils';
 
 const DEVTOOLS_SCOPE = 'https://api.shopify.com/auth/shop.storefront.devtools';
+const COLLABORATORS_SCOPE =
+  'https://api.shopify.com/auth/partners.collaborator-relationships.readonly';
 
 function getOauth2Client(origin: string) {
   const identityDomain = isDev(origin)
@@ -14,10 +16,7 @@ function getOauth2Client(origin: string) {
     ? env.DEV_OAUTH2_SUBJECT_ID
     : env.OAUTH2_SUBJECT_ID;
   const clientAuthParams = [
-    [
-      'scope',
-      `openid profile ${DEVTOOLS_SCOPE} https://api.shopify.com/auth/partners.collaborator-relationships.readonly`,
-    ],
+    ['scope', `openid profile ${DEVTOOLS_SCOPE} ${COLLABORATORS_SCOPE}`],
   ];
 
   return new Oauth2(clientId, subjectId, identityDomain, {clientAuthParams});
@@ -100,7 +99,7 @@ chrome.runtime.onMessage.addListener(({type, origin}, _, sendResponse) => {
   }
 
   const oauth2 = getOauth2Client(origin);
-  const params = [['scope', DEVTOOLS_SCOPE]];
+  const params = [['scope', `${DEVTOOLS_SCOPE} ${COLLABORATORS_SCOPE}`]];
   const destination = `${origin}/admin`;
 
   oauth2

--- a/src/background.ts
+++ b/src/background.ts
@@ -17,7 +17,7 @@ function getOauth2Client(origin: string) {
     [
       'scope',
       `openid profile ${DEVTOOLS_SCOPE} https://api.shopify.com/auth/partners.collaborator-relationships.readonly`,
-    ]
+    ],
   ];
 
   return new Oauth2(clientId, subjectId, identityDomain, {clientAuthParams});

--- a/src/background.ts
+++ b/src/background.ts
@@ -13,7 +13,7 @@ function getOauth2Client(origin: string) {
   const subjectId = isDev(origin)
     ? env.DEV_OAUTH2_SUBJECT_ID
     : env.OAUTH2_SUBJECT_ID;
-  const clientAuthParams = [['scope', `openid profile ${DEVTOOLS_SCOPE}`]];
+  const clientAuthParams = [['scope', `openid profile ${DEVTOOLS_SCOPE}`, 'https://api.shopify.com/auth/partners.collaborator-relationships.readonly']];
 
   return new Oauth2(clientId, subjectId, identityDomain, {clientAuthParams});
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -13,7 +13,13 @@ function getOauth2Client(origin: string) {
   const subjectId = isDev(origin)
     ? env.DEV_OAUTH2_SUBJECT_ID
     : env.OAUTH2_SUBJECT_ID;
-  const clientAuthParams = [['scope', `openid profile ${DEVTOOLS_SCOPE}`, 'https://api.shopify.com/auth/partners.collaborator-relationships.readonly']];
+  const clientAuthParams = [
+    [
+      'scope',
+      `openid profile ${DEVTOOLS_SCOPE}`,
+      'https://api.shopify.com/auth/partners.collaborator-relationships.readonly',
+    ],
+  ];
 
   return new Oauth2(clientId, subjectId, identityDomain, {clientAuthParams});
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Shopify Theme Inspector for Chrome",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Profile and debug Liquid template on your Shopify store",
   "devtools_page": "devtools.html",
   "permissions": ["storage", "identity", "activeTab"],


### PR DESCRIPTION
### What issue does this pull request address?

To enable the extension to be used by logged in collaborators we need an additional scope which is used to make the call to partners and check the user.

### What is the solution

Add the `https://api.shopify.com/auth/partners.collaborator-relationships.readonly` scope.

### What should the reviewer focus on and are there any special considerations?

This should not affect anything existing.
Same scope as being added here: https://github.com/Shopify/shopify/pull/242761/files#diff-633f5428c934e0c2687f5e582c6d9ab5R59
