### PR TITLE
Request employee scope when condition is met

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -16,7 +16,12 @@ function getOauth2Client(origin: string) {
     ? env.DEV_OAUTH2_SUBJECT_ID
     : env.OAUTH2_SUBJECT_ID;
   const clientAuthParams = [
-    ['scope', `openid profile ${DEVTOOLS_SCOPE} ${COLLABORATORS_SCOPE}`],
+    [
+      'scope',
+      `openid profile ${
+        (window as any).shopifyEmployee === true ? 'employee' : ''
+      } ${DEVTOOLS_SCOPE} ${COLLABORATORS_SCOPE}`,
+    ],
   ];
 
   return new Oauth2(clientId, subjectId, identityDomain, {clientAuthParams});
@@ -99,7 +104,14 @@ chrome.runtime.onMessage.addListener(({type, origin}, _, sendResponse) => {
   }
 
   const oauth2 = getOauth2Client(origin);
-  const params = [['scope', `${DEVTOOLS_SCOPE} ${COLLABORATORS_SCOPE}`]];
+  const params = [
+    [
+      'scope',
+      `${
+        (window as any).shopifyEmployee === true ? 'employee' : ''
+      } ${DEVTOOLS_SCOPE} ${COLLABORATORS_SCOPE}`,
+    ],
+  ];
   const destination = `${origin}/admin`;
 
   oauth2

--- a/src/background.ts
+++ b/src/background.ts
@@ -4,6 +4,7 @@ import {isDev, Oauth2} from './utils';
 const DEVTOOLS_SCOPE = 'https://api.shopify.com/auth/shop.storefront.devtools';
 const COLLABORATORS_SCOPE =
   'https://api.shopify.com/auth/partners.collaborator-relationships.readonly';
+let shopifyEmployee = false;
 
 function getOauth2Client(origin: string) {
   const identityDomain = isDev(origin)
@@ -19,7 +20,7 @@ function getOauth2Client(origin: string) {
     [
       'scope',
       `openid profile ${
-        (window as any).shopifyEmployee === true ? 'employee' : ''
+        shopifyEmployee === true ? 'employee' : ''
       } ${DEVTOOLS_SCOPE} ${COLLABORATORS_SCOPE}`,
     ],
   ];
@@ -62,6 +63,20 @@ chrome.runtime.onMessage.addListener(({type, origin}, _, sendResponse) => {
     });
 
   return true;
+});
+
+// Create a listener which handles when detectShopify.js, which executes in the
+// the same context as a tab, sends the results of of whether or not a Shopify
+// employee was detected
+chrome.runtime.onMessage.addListener((event, sender) => {
+  if (
+    sender.tab &&
+    sender.tab.id &&
+    event.type === 'detect-shopify-employee' &&
+    event.hasDetectedShopifyEmployee === true
+  ) {
+    shopifyEmployee = true;
+  }
 });
 
 // Create a listener which handles when detectShopify.js, which executes in the
@@ -108,7 +123,7 @@ chrome.runtime.onMessage.addListener(({type, origin}, _, sendResponse) => {
     [
       'scope',
       `${
-        (window as any).shopifyEmployee === true ? 'employee' : ''
+        shopifyEmployee === true ? 'employee' : ''
       } ${DEVTOOLS_SCOPE} ${COLLABORATORS_SCOPE}`,
     ],
   ];

--- a/src/detectShopify.ts
+++ b/src/detectShopify.ts
@@ -14,3 +14,10 @@ if (findShopifyScript.length) {
     hasDetectedShopify: true,
   });
 }
+
+if (document.location.search.includes('shopify_employee')) {
+  chrome.runtime.sendMessage({
+    type: 'detect-shopify-employee',
+    hasDetectedShopifyEmployee: true,
+  });
+}


### PR DESCRIPTION
### What issue does this pull request address?

Allow Shopify employees to use the dev tool.

### What is the solution

We can change the `window.shopifyEmployee` in the console to trigger the employee login. This will avoid confusion with users using the tools on their shop. 

### What should the reviewer focus on and are there any special considerations?
Is there a way to avoid going into the extension console and use the current tab console to modify the value of `window.shopifyEmployee`?
