### PR TITLE
Update Readme with links to issue #55 and PR #63

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ If you see this error, it may be because of one of the following conditions:
   * You might be trying to profile a checkout page, which is not supported by this extension.
   * There was an unhandled error in the request, e.g. timeout, lost connection, etc.
   * You might be trying to profile a development store. We can't profile it yet when you're logged in as the owner. See [issue #55](https://github.com/Shopify/shopify-theme-inspector/issues/55) for a workaround.
+  * This might be a known bug: If your store uses Storefront Renderer, we can't profile it yet. We're working hard to fix it. Subscribe to [pull request #63](https://github.com/Shopify/shopify-theme-inspector/pull/63) to get updates.
 
 If it was none of the errors above you can right click on Shopify DevTools , inspect page, and view console for error details.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ If you see this error, it may be because of one of the following conditions:
   * Your account does not have access to the current store you are trying to profile.
   * You might be trying to profile a checkout page, which is not supported by this extension.
   * There was an unhandled error in the request, e.g. timeout, lost connection, etc.
+  * You might be trying to profile a development store. We can't profile it yet when you're logged in as the owner. See [issue #55](https://github.com/Shopify/shopify-theme-inspector/issues/55) for a workaround.
 
 If it was none of the errors above you can right click on Shopify DevTools , inspect page, and view console for error details.
 


### PR DESCRIPTION
For better visibility and to minimize the number of "duplicate issues" created by people trying the extension, let visitors know ahead about the two known bugs: not being able to profile a development store, and not being able to profile a Storefront Renderer rendered store.

### What issue does this pull request address?

When new users of the extension get hit with the error message "This page cannot be profiled" they aren't given any reason why. Hence they may open issues that are later closed because it was later found to be one of the two problems: development store (#55) or SFR-rendered store (#63).

### What is the solution?

Inform all visitors in the FAQ section of the Readme about these two known issues so they can visit the appropriate issue, utilize the known workaround or subscribe to the pull request for updates.

### What should the reviewer focus on and are there any special considerations?

Consider that this would reduce the number of duplicate issues you may get, thus have to manage. Less time managing duplicate issues means more time fixing code 😄

