### PR TITLE
Fix cannot profile error

### DIFF
--- a/src/utils/getProfileData.ts
+++ b/src/utils/getProfileData.ts
@@ -31,8 +31,13 @@ function noProfileFound(document: HTMLDocument) {
   return document.querySelector('#liquidProfileData') === null;
 }
 
-function requestAccessToken({origin}: URL): Promise<SubjectAccessToken> {
-  return new Promise((resolve, reject) => {
+async function requestAccessToken({origin}: URL): Promise<SubjectAccessToken> {
+  let executeScript = chrome.tabs.executeScript({
+    file: "/detectShopify.js"
+  })
+
+  await Promise.resolve(executeScript);
+  return await new Promise((resolve, reject) => {
     return chrome.runtime.sendMessage(
       {type: 'request-core-access-token', origin},
       ({token, error}) => {
@@ -40,7 +45,7 @@ function requestAccessToken({origin}: URL): Promise<SubjectAccessToken> {
           return reject(error);
         }
         return resolve(token);
-      },
+      }
     );
   });
 }


### PR DESCRIPTION
### What issue does this pull request address?
This PR addresses [issue 72](https://github.com/Shopify/shopify-theme-inspector/issues/72)

How to reproduce the issue locally?
Make sure extension is installed locally and shop1 is already open in a tab.
1. Load or refresh any other page on your browser.
2. This will cause the `detectShopify.js` content script to run which will set the default value of `renderBackend` in `background.js` to SFR.
3. Navigate back to local shop page and try to run profile without refreshing page.
4. This will give an error because the local shop runs on core and the request made to identity for the access token is according to SFR since that's the value it defaults to if detectShopify is not able to find core through regex. `detectShopify` was run in the other tab which was not our shop store and hence `renderBackend` does not have the correct value.
For example the request is made in this format `https://identity.myshopify.io/oauth/client?name%5B%5D=shopify-development` and the name param is determined from the detectShopify script.

The subject id in making a profile request and getting an access token is tied to whether the render backend is core or SFR. The content script `detectShopify.js` is used for this purpose and the reason this bug gets fixed by refreshing the page is that the script is able to run upon page refresh and also able to detect the correct render backend.

### What is the solution

Proposed fix is to make sure the `detectShopify` content script runs when the load profile button is clicked so even without refreshing the shop page it will be able to detect the correct `renderBackend`. 

### What should the reviewer focus on and are there any special considerations?

Current implementation does not work effectively since it requires clicking the load profile button twice. We rely on background listening to `detect-shopify` event which sets `renderBackend`. How can we make sure the `requestAccessToken` only continues execution once the script has run and message has been successfully handled by `background`.

