### PR TITLE
Fix multiline code snippet text wrapping

### DIFF
--- a/src/styles/devtools.css
+++ b/src/styles/devtools.css
@@ -174,6 +174,7 @@ body {
   background-color: var(--toolbar-background-color);
   border: 1px solid var(--toolbar-border-color);
   padding: 4px 8px;
+  line-height: 2.5;
 }
 
 [data-theme="dark"] a {


### PR DESCRIPTION
### What issue does this pull request address?

Before:
<img width="653" alt="Screen Shot 2021-01-26 at 1 40 16 PM" src="https://user-images.githubusercontent.com/77689495/105909255-2bf74000-5fdc-11eb-85cf-ae7102ca1ad2.png">

After:
<img width="655" alt="Screen Shot 2021-01-26 at 1 40 27 PM" src="https://user-images.githubusercontent.com/77689495/105909275-3285b780-5fdc-11eb-9ec3-b9d28523fae1.png">

### What is the solution

Add a line height spacing to the CSS

### What should the reviewer focus on and are there any special considerations?
