### PR TITLE
Fix profiling for stores with custom domains

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -84,7 +84,7 @@ function clear() {
 function getInspectedWindowURL(): Promise<URL> {
   return new Promise(resolve => {
     chrome.devtools.inspectedWindow.eval(
-      `(/myshopify\\.io/.test(document.location.host) ? document.location.host : Shopify.shop) + document.location.pathname + document.location.search`,
+      `document.location.host + document.location.pathname + document.location.search`,
       function(currentUrl: string) {
         resolve(new URL(`https://${currentUrl}`));
       },


### PR DESCRIPTION
### What issue does this pull request address?

/* Context about the problem such as a link to an issue or just a description */

When profiling any Shopify store with custom domain, the run fails with `This page cannot be profiled` message. After some investigating, I noticed that the extension is always doing the `?profile_liquid=true` request to the permanent `.myshopify.com` domain instead of the custom one:
<img width="1237" alt="image" src="https://github.com/Shopify/shopify-theme-inspector/assets/829189/6d7b66d0-7a10-4199-94dc-15e68f616b46">
As you can see (probably because of some recent configuration changes), this results in the 301 redirect to the custom domain. The problem is that this makes the request lose the `Authorization` header and so it fails.

### What is the solution

/* Describe the solutions effectively */

I'm not sure what was the original reason for the conditional, but it seems like we can just always use the `document.location.host`. I haven't set the extension locally, but overwriting the value of `Shopify.shop` to be the custom domain fixes the issue and lets me profile the store properly.

### What should the reviewer focus on and are there any special considerations?

/* Any additional details you would want to bring to attention */

