### PR TITLE
Ignore empty partials coming from dynamic sources

### DIFF
--- a/src/utils/getProfileData.ts
+++ b/src/utils/getProfileData.ts
@@ -54,7 +54,11 @@ function requestAccessToken(
 function formatLiquidProfileData(
   entries: ProfileNode[],
 ): FormattedProfileNode[] {
-  return entries.map((entry: ProfileNode) => {
+  return entries.reduce((formattedEntries: FormattedProfileNode[], entry: ProfileNode) => {
+    if (!entry.partial) {
+      return formattedEntries;
+    }
+
     const nameParts = entry.partial.split('/');
     let name = '';
     let filepath = null;
@@ -78,15 +82,17 @@ function formatLiquidProfileData(
       }`;
     }
 
-    return {
+    formattedEntries.push({
       name,
       filepath,
       value: entry.total_time,
       children: formatLiquidProfileData(entry.children),
       code: entry.code,
       line: entry.line_number,
-    };
-  });
+    });
+
+    return formattedEntries;
+  }, []);
 }
 
 function cleanProfileData(profileData: ProfileData) {


### PR DESCRIPTION
### What issue does this pull request address?

So I finally managed to reproduce a recent situation where I'm getting the `The page cannot be profiled` error.
During the investigation, I noticed the following error in extension's devtools:
<img width="534" alt="image" src="https://github.com/user-attachments/assets/3d83205c-031c-4ef8-bf0b-4ac4f1f5b77e">

The issue occurs when a certain page uses a dynamic source in one of the rich text areas. Here I set up an example product page on [my test store](https://krzksz-test-store.myshopify.com/products/the-multi-location-snowboard) (password: `pierogi`), which references the product's vendor.

It triggers the error, because its entry contains only a code snippet:
<img width="503" alt="image" src="https://github.com/user-attachments/assets/5d4a4a98-ef32-4e91-9a20-7505c2d6f020">
so the `const nameParts = entry.partial.split('/');` part fails.

### What is the solution

I don't think showing a dynamic source entry on the flamechart would be actionable. Also, the parent that renders it still included properly.

That's why I decided to skip any entries that don't have the `.partial` defined, which fixes the issue.

### What should the reviewer focus on and are there any special considerations?

Fixes #121, fixes #137, fixes #138, fixes #139, fixes #140.